### PR TITLE
Change pygame to pygame-ce in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,18 +106,18 @@ python atari.py
 
 ### Dependencies
 - Python 3.13
-- pygame
+- pygame-ce
 - numpy (optional, used for sound effects)
 
 ### pip installation
 
 ```bash
-pip install pygame
+pip install pygame-ce
 ```
 
 For sound effects:
 ```bash
-pip install pygame numpy
+pip install pygame-ce numpy
 ```
 
 ---


### PR DESCRIPTION

## What does this PR do, and why?

<!-- A short description of your change. What problem does it solve or what does it add? -->

Updated installation instructions to use pygame-ce instead of pygame.

---

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [X] Documentation update
- [ ] Other (describe below)

---

## Related issue (if applicable)

<!-- Every PR should have a corresponding issue. If one does not exist, please open one before submitting. -->

Closes #

---

## Testing

<!-- How did you verify your change works? -->

- [ ] Ran `python atari.py` locally and the game launches without errors
- [ ] Tested the specific feature or fix I changed
- [ ] No new linting errors (`ruff check atari.py` passes)

---

## Checklist

- [ ] My code follows the existing style of the project
- [ ] I have not introduced any unnecessary dependencies
- [ ] I have updated `Checklist.md` if this closes an open issue
- [ ] I have added or updated comments where the code is non-obvious
- [ ] I have read and agree to the [MIT License](../LICENCE) terms

---

## Notes

<!-- Optional. Anything you want to flag to the maintainer — design decisions, trade-offs, or areas you are unsure about. Leave blank if not applicable. -->
